### PR TITLE
Keeping HookTest below v2.0 for compatibility.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: "zulu"
           java-version: "11"
       - name: Install Hooktest
-        run: pip3 install HookTest
+        run: pip3 install "HookTest<2.0"
       - name: Run Hooktest
         run:  hooktest --console --scheme auto --guidelines 2.epidoc --workers 3 --verbose 7 --manifest --countword ./
       # Include manifest.txt as a job artifact so we can re-use it when creating the release.


### PR DESCRIPTION
I am proposing this change to pin HookTest to <2.0 to ensure your repository remains functional. The upcoming HookTest v2.0 (scheduled for release the week of June 22nd) only supports CiteStructure approaches, which would break your current setup. By pinning the version now, you can maintain stability.